### PR TITLE
Add AI/ML API integration docs

### DIFF
--- a/docs/components/react/multi-provider-content/utils.ts
+++ b/docs/components/react/multi-provider-content/utils.ts
@@ -15,6 +15,23 @@ export const quickStartProviders: ProvidersConfig = {
     adapterImport: "OpenAIAdapter",
     adapterSetup: "const serviceAdapter = new OpenAIAdapter();",
   },
+  "aiml-api": {
+    id: "aiml-api",
+    title: "AI/ML API",
+    icon: "/icons/openai.png",
+    packageName: "openai",
+    envVarName: "AIML_API_KEY",
+    adapterImport: "OpenAIAdapter",
+    extraImports: `
+            import OpenAI from 'openai';
+        `,
+    clientSetup: `
+const openai = new OpenAI({
+  apiKey: process.env.AIML_API_KEY,
+  baseURL: '<your-aimlapi-endpoint>'
+});`,
+    adapterSetup: "const serviceAdapter = new OpenAIAdapter({ openai });",
+  },
   azure: {
     id: "azure",
     title: "Azure OpenAI",

--- a/docs/content/docs/(root)/guides/aiml-api-integration.mdx
+++ b/docs/content/docs/(root)/guides/aiml-api-integration.mdx
@@ -1,0 +1,36 @@
+---
+title: "AI/ML API Integration"
+description: "Use the AI/ML API with CopilotKit via the OpenAIAdapter."
+icon: "lucide/Brain"
+---
+
+The **AI/ML API** exposes an OpenAI compatible Chat Completion endpoint. This means you can reuse the
+existing `OpenAIAdapter` by pointing the OpenAI client at the custom base URL.
+
+## Example
+
+```ts title="app/api/copilotkit/route.ts" showLineNumbers
+import { CopilotRuntime, OpenAIAdapter, copilotRuntimeNextJSAppRouterEndpoint } from "@copilotkit/runtime";
+import OpenAI from "openai";
+import { NextRequest } from "next/server";
+
+const openai = new OpenAI({
+  apiKey: process.env.AIML_API_KEY,
+  baseURL: "https://api.aimlapi.example.com/v1", // your AI/ML API endpoint
+});
+
+const serviceAdapter = new OpenAIAdapter({ openai, model: "<model-id>" });
+const runtime = new CopilotRuntime();
+
+export const POST = async (req: NextRequest) => {
+  const { handleRequest } = copilotRuntimeNextJSAppRouterEndpoint({
+    runtime,
+    serviceAdapter,
+    endpoint: "/api/copilotkit",
+  });
+
+  return handleRequest(req);
+};
+```
+
+Replace `AIML_API_KEY` and the `baseURL` with the credentials provided by your AI/ML API deployment.

--- a/docs/content/docs/(root)/guides/meta.json
+++ b/docs/content/docs/(root)/guides/meta.json
@@ -13,6 +13,7 @@
     "guardrails",
     "copilot-suggestions",
     "bring-your-own-llm",
+    "aiml-api-integration",
     "copilot-textarea",
     "self-hosting",
     "messages-localstorage"


### PR DESCRIPTION
## Summary
- document how to use a custom AI/ML API endpoint with `OpenAIAdapter`
- update docs navigation
- add AI/ML API provider entry to the multi-provider utilities

## Testing
- `npm test` *(fails: Error: no test specified)*
- `pnpm test` *(fails: Error: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_68529eff956c8329845db805eb9e715e